### PR TITLE
remove extra spaces in regexp, fix version listing

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -15,4 +15,4 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions)
+echo $(eval "$cmd" | grep -oE "tag_name\": ?\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)


### PR DESCRIPTION
This change fixes version listing: `asdf list-all terragrunt`

The output of `curl -s https://api.github.com/repos/gruntwork-io/terragrunt/releases` does not contain spaces after `"tag_name":`, which is why the returned list was always emtpy.

This PR also fixes other asdf features that depend on the version, such as `asdf install terragrunt latest`.

Have a nice day :-)